### PR TITLE
Fix bug when using stone then petrification

### DIFF
--- a/Enemy.cpp
+++ b/Enemy.cpp
@@ -370,7 +370,12 @@ void Enemy::getPushedBack(float displacement, float duration)
 
 void Enemy::getPetrified(float duration)
 {
-	originalPosition.x += position.x - attackedOriginalPosition.x;
+	if (currentAttackedState != None 
+		&& currentAttackedState != PushedBackRight 
+		&& currentAttackedState != PushedBackLeft) 
+	{
+		originalPosition.x += position.x - attackedOriginalPosition.x;
+	}
 	petrifiedTime = duration;
 	petrifiedPassedTime = 0.f;
 	color = DirectX::Colors::White * 0.7f;


### PR DESCRIPTION
Fix bug where using petrification when stone attack animation is not finished moves enemy to a wrong position.